### PR TITLE
New release logic

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,12 +17,12 @@ jobs:
         run: sudo apt-get install zip
 
       - name: Create archives
-        run: for d in ./*; do if [ -d "$d" ]; then cd "$d"; zip ../"$d".cna *; cd ..; fi; done
+        run: sudo ./create_cnapy_projects_zip.sh
 
       - name: Upload assets
         uses: softprops/action-gh-release@v0.1.5
         with:
           # Newline-delimited list of path globs for asset files to upload
-          files: ./*.cna
+          files: ./*.zip
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,5 +1,12 @@
 # CNApy-projects
 
-A repository of CNApy projects. The project files (.cna) are created automatically on release by zipping the directories in the repository.
+A repository of CNApy projects and associated scenarios.
 
 The latest release can be downloaded here: https://github.com/cnapy-org/CNApy-projects/releases/latest
+
+The project files (.cna) are created automatically on release in the
+following way: First, for each subdirectory, all files which are *not* .scen (the scenario files) are
+zipped into a .cna file. Then, this .cna file is moved into its own new temporary directory with the
+same name as the subdirectory. In addition, all files which *are* .scen are also moved into this new temporary directory. Finally, all newly created directories are zipped together as a huge .zip file
+called "cnapy_projects.zip". This .zip file is then automatically added as an asset to the current
+CNA projects release.

--- a/README.md
+++ b/README.md
@@ -7,6 +7,6 @@ The latest release can be downloaded here: https://github.com/cnapy-org/CNApy-pr
 The project files (.cna) are created automatically on release in the
 following way: First, for each subdirectory, all files which are *not* .scen (the scenario files) are
 zipped into a .cna file. Then, this .cna file is moved into its own new temporary directory with the
-same name as the subdirectory. In addition, all files which *are* .scen are also moved into this new temporary directory. Then, all newly created directories are zipped together as a huge .zip file
+same name as the subdirectory. In addition, all files which *are* .scen are also moved into this new temporary directory. Then, all newly created directories are zipped together as one big .zip file
 called "all_cnapy_projects.zip". This .zip file is then automatically added as an asset to the current
 CNA projects release. Finally, all single projects are also zipped, each on their own, as .zip files.

--- a/README.md
+++ b/README.md
@@ -7,6 +7,6 @@ The latest release can be downloaded here: https://github.com/cnapy-org/CNApy-pr
 The project files (.cna) are created automatically on release in the
 following way: First, for each subdirectory, all files which are *not* .scen (the scenario files) are
 zipped into a .cna file. Then, this .cna file is moved into its own new temporary directory with the
-same name as the subdirectory. In addition, all files which *are* .scen are also moved into this new temporary directory. Finally, all newly created directories are zipped together as a huge .zip file
-called "cnapy_projects.zip". This .zip file is then automatically added as an asset to the current
-CNA projects release.
+same name as the subdirectory. In addition, all files which *are* .scen are also moved into this new temporary directory. Then, all newly created directories are zipped together as a huge .zip file
+called "all_cnapy_projects.zip". This .zip file is then automatically added as an asset to the current
+CNA projects release. Finally, all single projects are also zipped, each on their own, as .zip files.

--- a/create_cnapy_projects_zip.sh
+++ b/create_cnapy_projects_zip.sh
@@ -1,0 +1,55 @@
+zip_package_path=./_zip_package
+# Create temporary subfolder in which
+# all other new temporary folders for each
+# project will be generated
+if [ -d $zip_package_path ]
+then
+  rm -rf $zip_package_path
+fi
+mkdir $zip_package_path
+
+# Go through each project subfolder
+for d in ./*
+do
+  # Move the .scen files into a temporary
+  # folder so that they are not zipped together
+  # into the .cna file
+  if [ -d "$d" ]
+  then
+    echo $d
+    cd "$d"
+
+    for f in ./*
+    do
+      echo $f
+      if [[ $f == *.scen ]]
+      then
+          mkdir "../_scen_temp" -v
+          cp $f "../_scen_temp"/$f
+      fi
+    done
+
+    # zip .cna files (without the moved .scen files)
+    package_dir=."$zip_package_path"/"${d:2}"
+    mkdir $package_dir -v
+    zip_path="$package_dir"/"${d:2}".cna
+    zip $zip_path *
+
+    # Move - if there are any - the .scen files
+    # into the temporary project subfolder
+    if [ -d "../_scen_temp" ]
+    then
+        mv ../_scen_temp/* $package_dir
+        rm -rf "../_scen_temp"
+    fi
+
+    cd ..
+  fi
+done
+
+# Zip everything together
+rm -rf "$zip_package_path"/"${zip_package_path:2}"
+cd $zip_package_path
+zip -r ../cnapy_projects.zip *
+cd ..
+rm -rf $zip_package_path

--- a/create_cnapy_projects_zip.sh
+++ b/create_cnapy_projects_zip.sh
@@ -47,9 +47,19 @@ do
   fi
 done
 
-# Zip everything together
 rm -rf "$zip_package_path"/"${zip_package_path:2}"
 cd $zip_package_path
-zip -r ../cnapy_projects.zip *
+
+# Zip everything together
+zip -r ../all_cnapy_projects.zip *
+
+# Create single-project .zip files
+for d in ./*
+do
+  cd $d
+  zip -r ../../${d:2}.zip *
+  cd ..
+done
+
 cd ..
 rm -rf $zip_package_path


### PR DESCRIPTION
Based on an idea from @axelvonkamp , releases now get an asset which is a huge .zip file containing the .cna files in their own folders as well as (if there any) the .scen files aside of them.
With this new release logic, the user only has to download one file and scnearios can be easily bundled with them.